### PR TITLE
Fixed usage of docstring and sourccode for explanations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>com.wse</groupId>
     <artifactId>qanary-explanation-service</artifactId>
-    <version>3.14.0</version>
+    <version>3.14.1</version>
     <name>Qanary explanation service</name>
     <description>Webservice for rule-based explanation of QA-Systems as well as specific components</description>
     <properties>

--- a/src/main/java/com/wse/qanaryexplanationservice/helper/pojos/MethodItem.java
+++ b/src/main/java/com/wse/qanaryexplanationservice/helper/pojos/MethodItem.java
@@ -16,7 +16,7 @@ public class MethodItem {
     String docstring;
     String sourceCode;
 
-    public MethodItem(String caller, String callerName, String methodName, List<Variable> inputVariables, List<Variable> outputVariables, String annotatedAt, String annotatedBy) {
+    public MethodItem(String caller, String callerName, String methodName, List<Variable> inputVariables, List<Variable> outputVariables, String annotatedAt, String annotatedBy, String docstring, String sourceCode) {
         this.caller = caller;
         this.callerName = callerName == null ? caller : callerName;
         this.methodName = methodName;
@@ -24,6 +24,8 @@ public class MethodItem {
         this.outputVariables = outputVariables;
         this.annotatedAt = annotatedAt;
         this.annotatedBy = annotatedBy;
+        this.docstring = docstring;
+        this.sourceCode = sourceCode;
     }
 
     public String getDocstringRepresentation() {

--- a/src/main/java/com/wse/qanaryexplanationservice/repositories/QanaryRepository.java
+++ b/src/main/java/com/wse/qanaryexplanationservice/repositories/QanaryRepository.java
@@ -163,6 +163,8 @@ public class QanaryRepository {
         String annotatedBy = safeGetString(qs, "annotatedBy");
         List<Variable> inputVariables = this.extractVarsAndType(ExplanationHelper.VARIABLE_SEPARATOR, qs, this.SPARQL_VARNAME_INPUT_VARIABLES);
         List<Variable> outputVariables = this.extractVarsAndType(ExplanationHelper.VARIABLE_SEPARATOR, qs, this.SPARQL_VARNAME_OUTPUT_VARIABLES);
+        String docstring = safeGetString(qs, "docstring");
+        String sourceCode = safeGetString(qs, "sourceCode");
         return new MethodItem(
                 caller,
                 callerName,
@@ -170,7 +172,9 @@ public class QanaryRepository {
                 inputVariables,
                 outputVariables,
                 annotatedAt,
-                annotatedBy);
+                annotatedBy,
+                docstring,
+                sourceCode);
     }
 
     public List<Variable> extractVarsAndType(String separator, QuerySolution querySolution, Map<String, String> variableNamesMap) {

--- a/src/main/resources/queries/fetch_one_method_id.rq
+++ b/src/main/resources/queries/fetch_one_method_id.rq
@@ -5,7 +5,7 @@ PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>
 PREFIX  x:    <http://example.org#>
 PREFIX  prov: <http://www.w3.org/ns/prov#>
 
-SELECT  ?id ?caller ?callerName ?annotatedBy ?method ?outputDataType ?outputDataValue ?annotatedAt (GROUP_CONCAT(?inputDataValue; SEPARATOR=?separator) AS ?inputDataValues) (GROUP_CONCAT(?inputDataType; SEPARATOR=?separator) AS ?inputDataTypes)
+SELECT  ?id ?caller ?callerName ?annotatedBy ?method ?docstring ?sourceCode ?outputDataType ?outputDataValue ?annotatedAt (GROUP_CONCAT(?inputDataValue; SEPARATOR=?separator) AS ?inputDataValues) (GROUP_CONCAT(?inputDataType; SEPARATOR=?separator) AS ?inputDataTypes)
 FROM ?graph
 WHERE {
   BIND(?methodIdentifier AS ?id)
@@ -34,4 +34,4 @@ WHERE {
         	      rdf:value ?inputDataValue .
   }
 }
-GROUP BY ?id ?caller ?callerName ?annotatedBy ?outputDataType ?outputDataValue ?annotatedAt ?method
+GROUP BY ?id ?caller ?callerName ?annotatedBy ?outputDataType ?outputDataValue ?annotatedAt ?method ?docstring ?sourceCode

--- a/src/main/resources/queries/fetch_one_method_id.rq
+++ b/src/main/resources/queries/fetch_one_method_id.rq
@@ -22,6 +22,12 @@ WHERE {
       ?id x:output [ rdf:type ?outputDataType ; rdf:value ?outputDataValue ] ;
   }
   OPTIONAL {
+      ?id x:docstring ?docstring ;
+  }
+  OPTIONAL {
+      ?id x:sourceCode ?sourceCode ;
+  }
+  OPTIONAL {
 	  ?id x:input ?input .
   	    ?input (rdf:rest*/rdf:first) ?item .
   		    ?item rdf:type ?inputDataType ;

--- a/src/test/java/com/wse/qanaryexplanationservice/services/TemplateExplanationsServiceTest.java
+++ b/src/test/java/com/wse/qanaryexplanationservice/services/TemplateExplanationsServiceTest.java
@@ -359,7 +359,7 @@ public class TemplateExplanationsServiceTest {
 
         @Test
         void testExplainAggregatedMethodWithExplanations_Success() throws IOException, URISyntaxException {
-            MethodItem methodItem = new MethodItem("myCaller", "myCallerName", "myMethod", new ArrayList<Variable>(), new ArrayList<Variable>(), "annotatedAt", "annotatedBy");
+            MethodItem methodItem = new MethodItem("myCaller", "myCallerName", "myMethod", new ArrayList<Variable>(), new ArrayList<Variable>(), "annotatedAt", "annotatedBy", "docstring", "sourceCode");
             List<Method> childMethods = List.of(
                     new Method("id1", true, "Explanation 1"),
                     new Method("id2", true, "Explanation 2")
@@ -388,7 +388,9 @@ public class TemplateExplanationsServiceTest {
                     inputvars,
                     outputvarrs,
                     "date",
-                    "component"
+                    "component",
+                    "docstring",
+                    "sourcecode"
             );
             ExplanationMetaData data = new ExplanationMetaData("component", null, "graph", true, ExplanationHelper.getStringFromFile("/explanations/methods/en"), null, null, null, null, new ProcessingInformation(false, false));
             String explanation = templateExplanationsService.explainSingleMethod(data, method);
@@ -416,7 +418,9 @@ public class TemplateExplanationsServiceTest {
                     inputvars,
                     outputvars,
                     "date",
-                    "component"
+                    "component",
+                    "docstring",
+                    "sourceCode"
             );
         }
 


### PR DESCRIPTION
This PR adds support for fetching and handling docstring and sourceCode in the SPARQL query and corresponding Java data structures, and bumps the project version.

- Extended fetch_one_method_id.rq to optionally select docstring and sourceCode
- Updated QanaryRepository.transformQuerySolutionToMethodItem to extract the new fields
- Modified MethodItem to store docstring and sourceCode; bumped pom.xml version to 3.14.1
