### PR TITLE
Add Java CI test gate, CodeQL, grouped Dependabot & auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+# Grouped, weekly dependency updates per ecosystem.
+version: 2
+updates:
+  - package-ecosystem: maven
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      maven-minor-patch:
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: npm
+    directory: "/client"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      npm-minor-patch:
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns: ["*"]

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,36 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  schedule:
+    - cron: "0 3 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [java-kotlin, javascript-typescript]
+    steps:
+      - uses: actions/checkout@v4
+      - if: matrix.language == 'java-kotlin'
+        uses: actions/setup-java@v4
+        with:
+          distribution: corretto
+          java-version: "17"
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,28 @@
+# Auto-merge Dependabot patch/minor PRs once the required status checks pass.
+# GitHub still waits for the Java CI test gate before merging, so this is safe
+# as long as the Java CI workflow is a required check via branch protection.
+# Enable "Allow auto-merge" in Settings -> General.
+name: Dependabot auto-merge
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Enable auto-merge for patch & minor updates
+        if: ${{ steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor' }}
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,6 +3,8 @@ name: Docker Image CI
 on:
   workflow_dispatch:
   push:
+    branches: [main]
+    tags: ["*"]
 
 jobs:
   build:

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -1,0 +1,23 @@
+# Java CI test gate: builds and runs the unit/integration test suite on every
+# PR and push. The tests mock the external LLM/triplestore calls, so no secrets
+# are required. (The Docker image build/publish stays in docker-image.yml.)
+name: Java CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: corretto
+          java-version: "17"
+          cache: maven
+      - name: Build and test with Maven
+        run: mvn --batch-mode --update-snapshots test

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY --from=client_build /app/client/build/* src/main/resources/static
 WORKDIR /app
 RUN mvn clean install
 
-FROM openjdk:17-jdk-alpine
+FROM eclipse-temurin:17-jdk-alpine
 WORKDIR /app
 COPY --from=build /app/target/qanary-explanation-service-*.jar qanary-explanation-service.jar
 ENTRYPOINT ["java", "--add-opens", "java.base/java.io=ALL-UNNAMED", "--add-opens", "java.base/java.lang=ALL-UNNAMED", "-jar","qanary-explanation-service.jar"]


### PR DESCRIPTION
Part of the WSE-research repository-standardisation rollout. The only workflow was a Docker build/publish that ran on every push and needs registry + LLM secrets — there was no clean PR test gate.

## What this adds
- **`java-ci.yml`** — builds and runs the full test suite (**60 tests**, all mocking the external LLM/triplestore calls — verified to pass offline) on every PR/push.
- **`codeql.yml`** — weekly + PR CodeQL for `java-kotlin` and the JS/TS `client` (build-mode none).
- **`dependabot.yml`** — grouped weekly updates for **Maven**, the **npm** client, **Docker** and **GitHub Actions** (the repo had no Dependabot).
- **`dependabot-auto-merge.yml`** — auto-merge patch/minor Dependabot PRs behind the Java CI gate.
- Scoped **`docker-image.yml`** to pushes on `main` + tags (it previously ran its heavy node+maven image build on every branch, gating PRs).
- Fixed the deprecated **`openjdk:17-jdk-alpine`** runtime base → **`eclipse-temurin:17-jdk-alpine`** (the openjdk images were retired from Docker Hub).

🤖 Generated with [Claude Code](https://claude.com/claude-code)