### PR TITLE
Fix red build: BOM-manage Jackson; remove unused buildpack-platform (solves #72)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-cache</artifactId>
-            <version>2.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.springdoc</groupId>
@@ -97,8 +96,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.22.0
-            </version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
@@ -120,7 +117,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.22.0</version>
         </dependency>
         <dependency>
             <groupId>com.spotify</groupId>
@@ -131,11 +127,6 @@
             <groupId>io.swagger.core.v3</groupId>
             <artifactId>swagger-models</artifactId>
             <version>2.2.52</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-buildpack-platform</artifactId>
-            <version>3.1.2</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## The real problem behind #72
PR **#72** (bump `spring-boot-buildpack-platform` 3.1.2 → 4.1.0) fails CI — but so does **`main` itself**. The dominant failure is a **Jackson/spring-web version skew**: an earlier maven-minor-patch group pinned `jackson-databind` / `jackson-datatype-jsr310` to **2.22.0**, far ahead of what `spring-web 6.0.11` (Spring Boot 3.1.2) expects, so the Spring context fails to load:

```
NoClassDefFoundError: Could not initialize class
  org.springframework.web.reactive.function.client.DefaultExchangeStrategiesBuilder
```
→ 55 of 60 tests error out.

## Fix — align everything to the Spring Boot 3.1.2 BOM
- **jackson-databind / jackson-datatype-jsr310**: drop the explicit `2.22.0` pins → BOM-managed (2.15.x), matching spring-web 6.0.11.
- **spring-boot-starter-cache**: drop the stray `2.4.0` pin (a Spring Boot **2.4** starter inside a 3.1.2 project) → BOM-managed. *(This is what the stuck PR #66 tried to "fix" by jumping it to 4.1.0 — also wrong.)*
- **Remove the unused `spring-boot-buildpack-platform` dependency**: nothing in the source references it and all 60 tests pass without it. It is the artifact **#72** tried to bump to 4.1.0 — a Spring Boot **4** library that doesn't belong in a Spring Boot 3.1.2 project.

## Verified
`mvn test` → **BUILD SUCCESS, 60 tests, 0 failures/errors**.

Once merged I'll close **#72** and **#66** (both resolved here). The proper way to take any of these to 4.x is a deliberate Spring Boot 4 upgrade (parent + Java), tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)