### PR TITLE
build: upgrade to Spring Boot 4.1.0 (Spring Framework 7, JUnit 6)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.1.2</version>
+        <version>4.1.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.wse</groupId>
@@ -16,6 +16,18 @@
     <properties>
         <java.version>17</java.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- qa.commons -> stardog pulls jsr305 at several versions (1.3.9/3.0.0/3.0.1/3.0.2);
+                 pin one so the (stricter) Spring Boot 4 surefire classpath has no duplicate. -->
+            <dependency>
+                <groupId>com.google.code.findbugs</groupId>
+                <artifactId>jsr305</artifactId>
+                <version>3.0.2</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -35,25 +47,20 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-cache</artifactId>
-            <version>3.1.5</version>
         </dependency>
         <dependency>
             <groupId>com.knuddels</groupId>
             <artifactId>jtokkit</artifactId>
-            <version>0.6.1</version>
+            <version>1.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webflux</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-cache</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.1.0</version>
+            <version>3.0.3</version>
         </dependency>
         <dependency>
             <groupId>eu.wdaqua.qanary</groupId>
@@ -66,6 +73,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <!-- Spring Boot 4 moved MockMvc test auto-configuration (@AutoConfigureMockMvc)
+                 out of spring-boot-test-autoconfigure into this dedicated module. -->
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-webmvc-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>test</scope>
@@ -73,19 +87,16 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.9.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.9.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
-            <version>2.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -100,13 +111,6 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-webflux</artifactId>
-            <version>6.0.11</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven.surefire</groupId>
-            <artifactId>surefire-junit-platform</artifactId>
-            <version>3.5.6</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
@@ -139,14 +143,6 @@
                     <mainClass>
                         com.wse.qanaryexplanationservice.QanaryExplanationServiceApplication
                     </mainClass>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>15</source>
-                    <target>15</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/com/wse/qanaryexplanationservice/controller/ExplanationController.java
+++ b/src/main/java/com/wse/qanaryexplanationservice/controller/ExplanationController.java
@@ -60,13 +60,13 @@ public class ExplanationController {
             if (result != null)
                 return new ResponseEntity<>(result, HttpStatus.OK);
             else
-                return new ResponseEntity<>(null, HttpStatus.NOT_ACCEPTABLE);
+                return new ResponseEntity<>((Object) null, HttpStatus.NOT_ACCEPTABLE);
         } else {
             String result = this.explanationService.getTemplateComponentExplanation(graphURI, component, acceptHeader);
             if (result != null)
                 return new ResponseEntity<>(result, HttpStatus.OK);
             else
-                return new ResponseEntity<>(null, HttpStatus.BAD_REQUEST);
+                return new ResponseEntity<>((Object) null, HttpStatus.BAD_REQUEST);
         }
     }
 
@@ -120,7 +120,7 @@ public class ExplanationController {
             }
         } catch (Exception e) {
             logger.error("{}", e.getMessage());
-            return new ResponseEntity<>(null, HttpStatus.BAD_REQUEST);
+            return new ResponseEntity<>((Object) null, HttpStatus.BAD_REQUEST);
         }
         return new ResponseEntity<>(explanation, HttpStatus.OK);
     }
@@ -270,7 +270,7 @@ public class ExplanationController {
             String explanation = explanationService.getComposedExplanation(qanaryExplanationData);
             return new ResponseEntity<>(explanation, HttpStatus.OK);
         } catch (IOException e) {
-            return new ResponseEntity<>(null, HttpStatus.BAD_REQUEST);
+            return new ResponseEntity<>((Object) null, HttpStatus.BAD_REQUEST);
         }
     }
 

--- a/src/test/java/com/wse/qanaryexplanationservice/controller/ExplanationControllerTest.java
+++ b/src/test/java/com/wse/qanaryexplanationservice/controller/ExplanationControllerTest.java
@@ -5,9 +5,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -32,7 +32,7 @@ public class ExplanationControllerTest {
     @Autowired
     MockMvc mockMvc;
     String testRdfData;
-    @MockBean
+    @MockitoBean
     private ExplanationService explanationService;
     private ClassLoader classLoader = this.getClass().getClassLoader();
 

--- a/src/test/java/com/wse/qanaryexplanationservice/services/ExplanationServiceTest.java
+++ b/src/test/java/com/wse/qanaryexplanationservice/services/ExplanationServiceTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.io.IOException;
@@ -34,9 +34,9 @@ class ExplanationServiceTest {
     @Nested
     class PipelineTests {
 
-        @MockBean
+        @MockitoBean
         private QanaryRepository qanaryRepository;
-        @MockBean
+        @MockitoBean
         private TemplateExplanationsService templateExplanationsService;
         @Autowired
         private ExplanationService explanationService;

--- a/src/test/java/com/wse/qanaryexplanationservice/services/TemplateExplanationsServiceTest.java
+++ b/src/test/java/com/wse/qanaryexplanationservice/services/TemplateExplanationsServiceTest.java
@@ -21,8 +21,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.io.File;
@@ -150,9 +150,9 @@ public class TemplateExplanationsServiceTest {
             put("annotationofquestionlanguage", "/explanations/annotation_of_question_language/");
         }};
         private final ResultSet resultSet = serviceDataForTests.createResultSet(serviceDataForTests.getQuerySolutionMapList());
-        @SpyBean
+        @MockitoSpyBean
         private TemplateExplanationsService templateExplanationsService;
-        @MockBean
+        @MockitoBean
         private QanaryRepository qanaryRepository;
 
         @BeforeEach


### PR DESCRIPTION
## Why

Seven Dependabot PRs each fail on their own because they all require the **Spring Boot 4** platform. This is the single coordinated upgrade that lands them together (the proven pattern from Qanary_minimal #8).

Supersedes / resolves:

| PR | Bump | How |
|---|---|---|
| #68 | spring-boot-starter-parent 3.1.2 → **4.1.0** | parent bump |
| #65 | spring-webflux 6.0.11 → **7.0.8** | now BOM-managed |
| #71 | springdoc-openapi-starter-webmvc-ui 2.1.0 → **3.0.3** | explicit |
| #69 | hamcrest-library 2.2 → **3.0** | now BOM-managed |
| #67 | junit-jupiter-api 5.9.3 → **6.0.3** | now BOM-managed (SB4-shipped JUnit 6) |
| #82 | junit-jupiter-engine 5.9.3 → **6.0.3** | now BOM-managed |
| #64 | jtokkit 0.6.1 → **1.1.0** | explicit |

## Source/build changes required by Spring Framework 7 / Spring Boot 4

- **`ExplanationController`**: `new ResponseEntity<>(null, status)` became ambiguous (Spring 7 added a `ResponseEntity(MultiValueMap, HttpStatusCode)` overload); cast the null body to `(Object)`.
- **Tests**: `@MockBean`/`@SpyBean` were removed in Spring Boot 4 → migrated to Spring's `@MockitoBean`/`@MockitoSpyBean`.
- **`@AutoConfigureMockMvc`** moved to the new `spring-boot-webmvc-test` module → added that test dependency and updated the import.
- Let the BOM manage spring-webflux, `spring-boot-starter-cache`, JUnit and hamcrest (dropped explicit pins, removed a duplicate `starter-cache`); removed the stray `surefire-junit-platform` dependency.
- Pinned transitive **jsr305 → 3.0.2** (`qa.commons` → stardog pulls several versions) so Spring Boot 4's stricter surefire classpath has no duplicate key.
- Dropped the `maven-compiler-plugin` source/target **15** override so the declared `java.version` 17 (Spring Boot 4 baseline) applies.

## Verification

`mvn test` on **JDK 17** → **60 tests pass**, BUILD SUCCESS.

After this merges, #64/#65/#67/#68/#69/#71/#82 will be closed as superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)